### PR TITLE
Publish package on PyPi

### DIFF
--- a/.github/workflows/publish-to-mypy.yml
+++ b/.github/workflows/publish-to-mypy.yml
@@ -1,0 +1,29 @@
+name: Publish to PyPi
+on: [push]
+jobs:
+  mypy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.9
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Install mypy
+        run: python3 -m pip install build --user
+
+      - name: Build a binary wheel and a source tarball
+        run: >-
+          python3 -m
+          build
+          --sdist
+          --wheel
+          --outdir dist/
+
+    - name: Publish distribution to PyPI
+      if: startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Only tagged commits are published.

Implements #3 